### PR TITLE
Fix: getPosts에서 userId를 필수 파라미터에서 제외 

### DIFF
--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -554,17 +554,17 @@ DELETE /api/blog/:userId/category/:categoryId
 
 ### getPosts 글 목록 조회
 
-- 아이디에 해당하는 유저가 쓴 글 중 조건에 일치하는 글 목록 조회
+- 조건에 일치하는 글 목록 조회
 
 ```http request
-GET /api/post/:userId?categoryId=&order=recent&offset=0&limit=10
+GET /api/post?userId=&categoryId=&order=recent&offset=0&limit=10
 ```
 
 #### 요청
 
 | Param Type |     Name     | Data Type | Required |                           Description                            |  
 |:----------:|:------------:|:---------:|:--------:|:----------------------------------------------------------------:|
-|    Path    |   `userId`   | `String`  |    O     |                              유저 아이디                              |
+|   Query    |   `userId`   | `String`  |    -     |                              유저 아이디                              |
 |   Query    | `categoryId` |   `int`   |    -     |          게시판 아이디. 특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록          |
 |   Query    |   `order`    | `String`  |    -     | `latest(최신순)`,`oldest(오래된순)`,`popular(인기순)` 중 택 1. 기본값은 `latest` |
 |   Query    |   `offset`   |   `int`   |    -     |                  정렬된 결과 중 `offset`부터 반환. 기본값 0                   |

--- a/myBlog-api/resources/sql/02.data.sql
+++ b/myBlog-api/resources/sql/02.data.sql
@@ -12,10 +12,14 @@
 USE `myBlog`;
 
 INSERT INTO myBlog.User (id_str, pw, name, content)
-VALUES ('cheesecat47', '1234', '신주용', '안녕하세요, 신주용입니다.');
+VALUES ('cheesecat47', '1234', '신주용', '안녕하세요, 신주용입니다.'),
+       ('rosielsh', '1234', '이수화', '안녕하세요, 이수화입니다.');
 SET @user_cheesecat47 = (SELECT id
                          FROM myBlog.User
                          WHERE `id_str` = 'cheesecat47');
+SET @user_rosielsh = (SELECT id
+                         FROM myBlog.User
+                         WHERE `id_str` = 'rosielsh');
 
 INSERT INTO myBlog.ContactType (type)
 VALUES ('Email'),
@@ -39,40 +43,76 @@ INSERT INTO myBlog.Contact (user_id, type_id, value)
 VALUES (@user_cheesecat47, @contacttype_email, 'cheesecat47@gmail.com'),
        (@user_cheesecat47, @contacttype_github, 'https://github.com/cheesecat47'),
        (@user_cheesecat47, @contacttype_linkedin, 'https://www.linkedin.com/in/shinjuyong/'),
-       (@user_cheesecat47, @contacttype_website, 'https://cheesecat47.github.io');
+       (@user_cheesecat47, @contacttype_website, 'https://cheesecat47.github.io'),
+       (@user_rosielsh, @contacttype_github, 'https://github.com/cheesecat47');
 
 INSERT INTO myBlog.Blog (id, name)
-VALUES (@user_cheesecat47, 'La foret rouge');
+VALUES (@user_cheesecat47, 'La foret rouge'),
+       (@user_rosielsh, 'rosie.log');
 SET @blogid_cheesecat47 = (SELECT id
                            FROM myBlog.Blog
                            WHERE id = @user_cheesecat47);
+SET @blogid_rosielsh = (SELECT id
+                           FROM myBlog.Blog
+                           WHERE id = @user_rosielsh);
 
-INSERT INTO myBlog.Category (blog_id, name)
-VALUES (@blogid_cheesecat47, 'Java'),
-       (@blogid_cheesecat47, 'Spring Boot'),
-       (@blogid_cheesecat47, 'Vue.js'),
-       (@blogid_cheesecat47, '알고리즘 문제');
+INSERT INTO myBlog.Category (blog_id, name, deleted_at)
+VALUES (@blogid_cheesecat47, 'Java', null),
+       (@blogid_cheesecat47, 'Spring Boot', null),
+       (@blogid_cheesecat47, 'Vue.js', now()), -- 조회 결과에 안 나와야 함
+       (@blogid_cheesecat47, '알고리즘 문제', null),
+       (@blogid_rosielsh, 'Front-end', null),
+       (@blogid_rosielsh, '회고록', null),
+       (@blogid_rosielsh, 'CS', now()); -- 조회 결과에 안 나와야 함
 SET @categoryid_java = (SELECT id
                         FROM myBlog.Category
                         WHERE name = 'Java');
+SET @categoryid_vue = (SELECT id
+                        FROM myBlog.Category
+                        WHERE name = 'Vue.js');
 SET @categoryid_algo = (SELECT id
                         FROM myBlog.Category
                         WHERE name = '알고리즘 문제');
+SET @categoryid_fe = (SELECT id
+                        FROM myBlog.Category
+                        WHERE name = 'Front-end');
+SET @categoryid_cs = (SELECT id
+                      FROM myBlog.Category
+                      WHERE name = 'CS');
 
-INSERT INTO myBlog.Post (category_id, user_id, title, content)
+INSERT INTO myBlog.Post (category_id, user_id, title, content, hit, created_at, deleted_at)
 VALUES (@categoryid_java, @user_cheesecat47, 'Java 너무 재미있어요.',
-        'Java 너무 재미있어요. Objective Oriented Programming 익숙해지니 너무 좋아요.'),
-       (@categoryid_algo, @user_cheesecat47, '알고리즘 쉽지 않네요.', '다익스트라 알고리즘 조금 어려운 것 같아요. 다시 복습해야겠어요.');
+        'Java 너무 재미있어요. Objective Oriented Programming 익숙해지니 너무 좋아요.', 5,
+        date_sub(now(), interval 5 minute), null),
+       (@categoryid_java, @user_cheesecat47, 'Java 별로에요.',
+        '삭제된 게시글. 보이지 않아야 함.', 2,
+        date_sub(now(), interval 4 minute), now()),
+       (@categoryid_vue, @user_cheesecat47, 'Vue3 좋은데요?',
+        '삭제된 게시판. 보이지 않아야 함.', 1,
+        date_sub(now(), interval 3 minute), null),
+       (@categoryid_algo, @user_cheesecat47, '알고리즘 쉽지 않네요.', '다익스트라 알고리즘 조금 어려운 것 같아요. 다시 복습해야겠어요.', 5,
+        date_sub(now(), interval 2 minute), null),
+       (@categoryid_fe, @user_rosielsh, '프론트엔드 짱짱.',
+        '리액트로 프론트 공부하기!', 12,
+        date_sub(now(), interval 1 minute), null),
+       (@categoryid_cs, @user_rosielsh, 'CS 공부 할 거 엄청 많아.',
+        '삭제된 게시글. 보이지 않아야 함.', 3,
+        now(), now());
 SET @postid_java_1 = (SELECT id
                       FROM Post
                       WHERE title = 'Java 너무 재미있어요.');
 
-INSERT INTO myBlog.Comment (user_id, post_id, content)
-VALUES (@user_cheesecat47, @postid_java_1, '댓글댓글!');
+INSERT INTO myBlog.Comment (user_id, post_id, content, created_at, deleted_at)
+VALUES (@user_cheesecat47, @postid_java_1, '댓글댓글!',
+        date_sub(now(), interval 1 minute), null),
+       (@user_cheesecat47, @postid_java_1, '삭제된 댓글댓글!',
+        now(), now());
 
 INSERT INTO myBlog.UserProfileImage (id, path)
 VALUES (@user_cheesecat47,
-        'https://raw.githubusercontent.com/cheesecat47/myBlog/main/myBlog-frontend/src/assets/6B152AA5-CC62-49B6-913A-7C702AF22F1E_1_102_o.jpeg');
+        'https://raw.githubusercontent.com/cheesecat47/myBlog/main/myBlog-frontend/src/assets/6B152AA5-CC62-49B6-913A-7C702AF22F1E_1_102_o.jpeg'),
+       (@user_rosielsh,
+        'https://avatars.githubusercontent.com/u/72565083?v=4');
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
@@ -42,13 +42,13 @@ public class PostController {
             @ApiResponse(responseCode = "404", description = "글 목록 조회 실패"),
             @ApiResponse(responseCode = "500", description = "글 목록 조회 실패")
     })
-    @GetMapping(value = "/{userId}")
+    @GetMapping(value = "")
     public ResponseEntity<GetPostsResponse> getPosts(
-            @Parameter(description = "유저 아이디") @PathVariable String userId,
-            @RequestParam(required = false) String categoryId,
-            @RequestParam(required = false, defaultValue = "latest") String order,
-            @RequestParam(required = false, defaultValue = "0") String offset,
-            @RequestParam(required = false, defaultValue = "10") String limit
+            @Parameter(description = "유저 아이디") @RequestParam(required = false) String userId,
+            @Parameter(description = "게시판 아이디") @RequestParam(required = false) String categoryId,
+            @Parameter(description = "정렬 방법") @RequestParam(required = false, defaultValue = "latest") String order,
+            @Parameter(description = "offset: 몇 번째 글부터") @RequestParam(required = false, defaultValue = "0") String offset,
+            @Parameter(description = "limit: 몇 개의 글 조회 할지") @RequestParam(required = false, defaultValue = "10") String limit
     ) throws Exception {
         GetPostsRequest params = new GetPostsRequest();
         params.setUserId(userId);

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostServiceImpl.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostServiceImpl.java
@@ -27,34 +27,23 @@ public class PostServiceImpl implements PostService {
     public List<PostDto> getPosts(GetPostsRequest params) throws Exception {
         log.debug("getPosts: params: {}", params);
 
-        // 공백인 경우
-        if (params.getUserId().isEmpty() || params.getUserId().isBlank()) {
-            String msg = "유저 아이디는 필수입니다";
-            log.error("getPosts: {}", msg);
-            throw new MyBlogCommonException(
-                    ResponseCode.NO_REQUIRED_REQUEST_PARAMETER,
-                    msg,
-                    new HashMap<>() {{
-                        put("userId", params.getUserId());
-                    }}
-            );
-        }
-
         // DB에서 조회
         List<PostDto> posts;
         try {
             // 존재하는 유저인지 확인
-            UserInfoDto userInfoDto = userMapper.getUserInfo(params.getUserId());
-            if (userInfoDto == null) {
-                String msg = "입력한 아이디에 해당하는 유저가 없습니다";
-                log.error("getPosts: {}", msg);
-                throw new MyBlogCommonException(
-                        ResponseCode.NO_RESULT,
-                        msg,
-                        new HashMap<>() {{
-                            put("userId", params.getUserId());
-                        }}
-                );
+            if (params.getUserId() != null) {
+                UserInfoDto userInfoDto = userMapper.getUserInfo(params.getUserId());
+                if (userInfoDto == null) {
+                    String msg = "입력한 아이디에 해당하는 유저가 없습니다";
+                    log.error("getPosts: {}", msg);
+                    throw new MyBlogCommonException(
+                            ResponseCode.NO_RESULT,
+                            msg,
+                            new HashMap<>() {{
+                                put("userId", params.getUserId());
+                            }}
+                    );
+                }
             }
 
             posts = postMapper.getPosts(params);

--- a/myBlog-api/src/main/resources/mapper/post.xml
+++ b/myBlog-api/src/main/resources/mapper/post.xml
@@ -39,8 +39,10 @@
         from myBlog.Post
                  left outer join myBlog.User on Post.user_id = User.id
                  left outer join myBlog.Category on Post.category_id = Category.id
-        where myBlog.User.id_str = #{userId}
-          and Post.deleted_at is null -- 삭제된 글 정보 제외
+        where Post.deleted_at is null -- 삭제된 글 정보 제외
+          <if test="userId != null">
+              and myBlog.User.id_str = #{userId}
+          </if>
           <if test="categoryId > 0">
             and Category.id = #{categoryId}
           </if>


### PR DESCRIPTION
## 이슈

- #76

## 작업 사항

- getPosts에서 userId를 필수 파라미터에서 제외
- 유저 아이디 없이 조회하면 전체 게시글 중 인기글 등 조회 가능
- 테스트 가능하도록 샘플 데이터 업데이트
- API 명세서 업데이트

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.
