### PR TITLE
Docs: 미구현 API 명세 작성 

### DIFF
--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -12,6 +12,7 @@
     * [refresh 액세스 토큰 재발급](#refresh-액세스-토큰-재발급)
   * [Blog](#blog)
     * [getBlogInfo 블로그 정보 조회](#getbloginfo-블로그-정보-조회)
+    * [updateBlogInfo 블로그 정보 변경](#updatebloginfo-블로그-정보-변경)
   * [Category](#category)
     * [getCategories 게시판 목록 조회](#getcategories-게시판-목록-조회)
     * [createCategory 게시판 생성](#createcategory-게시판-생성)
@@ -528,17 +529,17 @@ curl -X 'POST' \
 
 ### getBlogInfo 블로그 정보 조회
 
-- 블로그 주인 유저 아이디를 사용해 해당 유저의 블로그 정보 조회.
+- 블로그 아이디를 사용해 해당 블로그 정보 조회.
 
 ```http request
-GET /api/blog/:userId
+GET /api/blog/:blogId
 ```
 
 #### 요청
 
-| Param Type |   Name   | Data Type | Required |      Description       | 
-|:----------:|:--------:|:---------:|:--------:|:----------------------:|
-|    Path    | `userId` | `String`  |    O     | 유저 아이디. DB의 `id_str` 값 |
+| Param Type |   Name   | Data Type | Required |          Description          | 
+|:----------:|:--------:|:---------:|:--------:|:-----------------------------:|
+|    Path    | `blogId` | `String`  |    O     | 블로그 아이디. 유저 아이디(`userId`)와 동일 |
 
 #### 응답
 
@@ -554,7 +555,7 @@ GET /api/blog/:userId
 
 |   Name    | Data Type |             Description              | 
 |:---------:|:---------:|:------------------------------------:|
-|  userId   | `String`  |    블로그 주인 유저 아이디. DB의 `id_str` 값     |
+|  blogId   | `String`  |    블로그 아이디. 유저 아이디(`userId`)와 동일     |
 | blogName  | `String`  |                블로그 이름                |
 |  content  | `String`  | 블로그 소개. 소개 멘트 부재 시 길이 0인 문자열 `""` 반환 |
 | createdAt | `String`  |     블로그 개설일. ISO 8601 형식. UTC 기준     |
@@ -587,6 +588,68 @@ GET /api/blog/:userId
   }
 }
 ``` 
+
+### updateBlogInfo 블로그 정보 변경
+
+- 블로그 정보 변경.
+
+```http request
+PUT /api/blog/:blogId
+```
+
+#### 요청
+
+| Param Type |   Name    | Data Type | Required |             Description              | 
+|:----------:|:---------:|:---------:|:--------:|:------------------------------------:|
+|    Path    | `blogId`  | `String`  |    O     |    블로그 아이디. 유저 아이디(`userId`)와 동일     |
+|    Body    | `content` | `String`  |    -     | 블로그 소개. 소개 멘트 부재 시 길이 0인 문자열 `""` 반환 |
+
+#### 응답
+
+##### 응답 본문
+
+|   Name    | Data Type | Description | 
+|:---------:|:---------:|:-----------:|
+| `message` | `String`  |   응답 메시지    |
+|  `code`   | `String`  |    응답 코드    |
+|  `data`   |   `Map`   |   오류 정보 맵   |
+
+##### 예시
+
+```json
+// HTTP/1.1 204 NO CONTENT
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "블로그 정보 변경 성공",
+  "code": "00",
+  "data": null
+}
+```
+
+```json
+// HTTP/1.1 400 BAD REQUEST
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "입력한 아이디에 해당하는 블로그가 없습니다.",
+  "code": "13",
+  "data": {
+    "blogId": "cheesecat$&"
+  }
+}
+``` 
+
+```json
+// HTTP/1.1 401 UNAUTHORIZED
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "블로그 정보 변경은 로그인 상태의 블로그 주인 유저만 가능합니다",
+  "code": "12",
+  "data": {
+    "Authorization": "Bearer eyJ0eXAiOi...",
+    "userId": "rosielsh"
+  }
+}
+```
 
 ## Category
 

--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -24,6 +24,7 @@
     * [updatePost 글 수정](#updatepost-글-수정)
     * [deletePost 글 삭제](#deletepost-글-삭제)
   * [Comment](#comment)
+    * [getCommentsByPostId 특정 글에 달린 댓글 목록 조회](#getcommentsbypostid-특정-글에-달린-댓글-목록-조회)
     * [createComment 댓글 작성](#createcomment-댓글-작성)
     * [updateComment 댓글 수정](#updatecomment-댓글-수정)
     * [deleteComment 댓글 삭제](#deletecomment-댓글-삭제)
@@ -939,7 +940,7 @@ GET /api/post?userId=&categoryId=&order=recent&offset=0&limit=10
 
 ### getPostById 글 상세 조회
 
-- 글 상세 조회. 이 글과 연결된 댓글 포함.
+- 글 상세 조회. 이 글과 연결된 댓글은 [getCommentsByPostId 특정 글에 달린 댓글 목록 조회](#getcommentsbypostid-특정-글에-달린-댓글-목록-조회) API 사용.
 
 ```http request
 GET /api/post/:userId/:postId
@@ -976,8 +977,6 @@ GET /api/post/:userId/:postId
 |    excerpt    |      `String`      |                  요약                   |
 |   thumbnail   |      `String`      |                썸네일 URL                |
 |    content    |      `String`      |                  본문                   |
-|   comments    | `List<CommentDto>` | 댓글 배열. 최근순 정렬. 댓글이 없으면 길이가 0인 배열 `[]` |
-| numOfComments |       `int`        |       댓글 개수 (`comments` 배열 길이)        |
 
 ##### UserInfoDto
 
@@ -987,23 +986,14 @@ GET /api/post/:userId/:postId
 |   nickName   |    `String`    |                  유저 별명                  |
 | profileImage | `String\|null` | 프로필 이미지 URL. `null`이면 임의의 기본 이미지로 대체 필요 |
 
-##### CommentDto
-
-|   Name    | Data Type |         Description         | 
-|:---------:|:---------:|:---------------------------:|
-| commentId |   `int`   |           댓글 아이디            |
-|  userId   | `String`  |         댓글 작성자 아이디          |
-|  content  | `String`  |            댓글 내용            |
-| createdAt | `String`  | 댓글 작성일. ISO 8601 형식. UTC 기준 |
-
 ##### 예시
 
 ```json
 // HTTP/1.1 200 OK
 // Content-Type: application/json;charset=UTF-8
 {
-  "message": "인기 글 목록 조회 성공",
-  "errors": null,
+  "message": "글 상세 조회 성공",
+  "code": "00",
   "data": {
     "postId": 4,
     "categoryId": 1,
@@ -1018,22 +1008,7 @@ GET /api/post/:userId/:postId
     "hit": 21,
     "excerpt": "2018년 10월에 동촌 유원지에 사진 찍으러 나갔다가 만난 아기 고양이. 진짜 예뻤다.",
     "thumbnail": "...",
-    "content": "2018년 10월에 동촌 유원지에 사진 찍으러 나갔다가 만난 아기 고양이. 진짜 예뻤다. 사람을 경계는 하면서도 멀리 도망가지는 않고 웅크리고 앉아서 지켜보는데 얼마나 귀엽던지.",
-    "comments": [
-      {
-        "commentId": 2,
-        "userId": "cheesecat47",
-        "content": "그치? ㅋㅋㅋ",
-        "createdAt": "2023-12-02T23:02:00Z"
-      },
-      {
-        "commentId": 1,
-        "userId": "rosielsh",
-        "content": "짱 귀여워!",
-        "createdAt": "2023-12-02T23:01:00Z"
-      }
-    ],
-    "numOfComments": 2
+    "content": "2018년 10월에 동촌 유원지에 사진 찍으러 나갔다가 만난 아기 고양이. 진짜 예뻤다. 사람을 경계는 하면서도 멀리 도망가지는 않고 웅크리고 앉아서 지켜보는데 얼마나 귀엽던지."
   }
 }
 ```
@@ -1254,6 +1229,86 @@ curl -X 'DELETE' \
 ```
 
 ## Comment
+
+### getCommentsByPostId 특정 글에 달린 댓글 목록 조회
+
+- 특정 글에 달린 댓글 목록 조회.
+
+```http request
+GET /api/post/:postId/comment
+```
+
+#### 요청
+
+| Param Type |   Name   | Data Type | Required | Description |
+|:----------:|:--------:|:---------:|:--------:|:-----------:|
+|    Path    | `postId` |   `int`   |    O     |   게시글 아이디   |
+
+#### 응답
+
+##### 응답 본문
+
+|   Name    | Data Type |    Description    | 
+|:---------:|:---------:|:-----------------:|
+| `message` | `String`  |      응답 메시지       |
+|  `code`   | `String`  |       응답 코드       |
+|  `data`   |   `Map`   | 응답 데이터 또는 오류 정보 맵 |
+
+##### data(Map)
+
+|     Name      |     Data Type      |              Description              | 
+|:-------------:|:------------------:|:-------------------------------------:|
+|   comments    | `List<CommentDto>` | 댓글 배열. 최근순 정렬. 댓글이 없으면 길이가 0인 배열 `[]` |
+| numOfComments |       `int`        |       댓글 개수 (`comments` 배열 길이)        |
+
+##### CommentDto
+
+|   Name    | Data Type |         Description         | 
+|:---------:|:---------:|:---------------------------:|
+| commentId |   `int`   |           댓글 아이디            |
+|  userId   | `String`  |         댓글 작성자 아이디          |
+|  content  | `String`  |            댓글 내용            |
+| createdAt | `String`  | 댓글 작성일. ISO 8601 형식. UTC 기준 |
+
+##### 예시
+
+```json
+// HTTP/1.1 200 OK
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "댓글 목록 조회 성공",
+  "code": "00",
+  "data": {
+    "comments": [
+      {
+        "commentId": 2,
+        "userId": "cheesecat47",
+        "content": "그치? ㅋㅋㅋ",
+        "createdAt": "2023-12-02T23:02:00Z"
+      },
+      {
+        "commentId": 1,
+        "userId": "rosielsh",
+        "content": "짱 귀여워!",
+        "createdAt": "2023-12-02T23:01:00Z"
+      }
+    ],
+    "numOfComments": 2
+  }
+}
+```
+
+```json
+// HTTP/1.1 400 BAD REQUEST
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "INVALID_REQUEST_PARAMETER",
+  "code": "11",
+  "data": {
+    "userId": "cheesecat$&"
+  }
+}
+```
 
 ### createComment 댓글 작성
 

--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -23,6 +23,10 @@
     * [createPost 글 작성](#createpost-글-작성)
     * [updatePost 글 수정](#updatepost-글-수정)
     * [deletePost 글 삭제](#deletepost-글-삭제)
+  * [Comment](#comment)
+    * [createComment 댓글 작성](#createcomment-댓글-작성)
+    * [updateComment 댓글 수정](#updatecomment-댓글-수정)
+    * [deleteComment 댓글 삭제](#deletecomment-댓글-삭제)
   * [에러 코드 정리](#에러-코드-정리)
   * [References](#references)
 
@@ -1241,6 +1245,200 @@ curl -X 'DELETE' \
 // Content-Type: application/json;charset=UTF-8
 {
   "message": "글 삭제는 로그인 상태의 블로그 주인 유저만 가능합니다",
+  "code": "12",
+  "data": {
+    "Authorization": "Bearer eyJ0eXAiOi...",
+    "userId": "rosielsh"
+  }
+}
+```
+
+## Comment
+
+### createComment 댓글 작성
+
+- 특정 글에 댓글 작성.
+
+```http request
+POST /api/post/:postId/comment
+```
+
+#### 요청
+
+| Param Type |      Name       | Data Type | Required |                    Description                    |
+|:----------:|:---------------:|:---------:|:--------:|:-------------------------------------------------:|
+|    Path    |    `postId`     |   `int`   |    O     |                       글 아이디                       |
+|    Body    |    `userId`     | `String`  |    -     |              유저 아이디. DB의 `id_str` 값               |
+|   Header   | `Authorization` | `String`  |    -     |         액세스 토큰. `userId`를 사용해 댓글 작성 시 필요          |
+|    Body    |    `content`    | `String`  |    -     |                  댓글 본문. 최대 300자                   |
+|    Body    |   `tmpUserId`   | `String`  |    -     | 비회원 댓글 시 유저 아이디. `userId` 또는 이 값 중 하나 필수. 둘 다는 불가 |
+|    Body    |   `tmpUserPw`   | `String`  |    -     |       비회원 댓글 시 유저 비밀번호. `tmpUserId` 사용 시 필요       |
+
+##### 예시
+
+```bash
+curl -X 'POST' \
+  'http://localhost:8080/api/post/1/comment' \
+  -H 'accept: application/json;charset=utf-8' \
+  -H 'Authorization: Bearer eyJ0eXAiOi...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "userId": "cheesecat47",
+  "content": "글 잘 보고 갑니다^^",
+}'
+```
+
+#### 응답
+
+##### 예시
+
+```json
+// HTTP/1.1 201 CREATED
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "댓글 생성 성공",
+  "code": "00",
+  "data": null
+}
+```
+
+```json
+// HTTP/1.1 400 BAD REQUEST
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "유저 아이디 형식에 맞지 않습니다",
+  "code": "11",
+  "data": {
+    "tmpUserId": "cheesecat$@"
+  }
+}
+```
+
+### updateComment 댓글 수정
+
+- 댓글 수정.
+
+```http request
+PUT /api/post/:postId/comment/:commentId
+```
+
+#### 요청
+
+| Param Type |      Name       | Data Type | Required |                          Description                           |
+|:----------:|:---------------:|:---------:|:--------:|:--------------------------------------------------------------:|
+|    Path    |    `postId`     |   `int`   |    O     |                             글 아이디                              |
+|    Path    |   `commentId`   |   `int`   |    O     |                             댓글 아이디                             |
+|    Body    |    `userId`     | `String`  |    -     |                     유저 아이디. DB의 `id_str` 값                     |
+|   Header   | `Authorization` | `String`  |    -     |              액세스 토큰. `userId`를 사용해 작성한 댓글 수정 시 필요              |
+|    Body    |    `content`    | `String`  |    -     |                      수정할 새 댓글 본문. 최대 300자                      |
+|    Body    |   `tmpUserId`   | `String`  |    -     | 비회원으로 작성한 댓글 수정 시 필요한 유저 아이디. `userId` 또는 이 값 중 하나 필수. 둘 다는 불가 |
+|    Body    |   `tmpUserPw`   | `String`  |    -     |            비회원 댓글 수정 시 유저 비밀번호. `tmpUserId` 사용 시 필요            |
+
+##### 예시
+
+```bash
+curl -X 'PUT' \
+  'http://localhost:8080/api/post/1/comment/1' \
+  -H 'accept: application/json;charset=utf-8' \
+  -H 'Authorization: Bearer eyJ0eXAiOi...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "userId": "cheesecat47",
+  "content": "글 잘 보고 갑니다!!",
+}'
+```
+
+#### 응답
+
+##### 예시
+
+```json
+// HTTP/1.1 204 NO CONTENT
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "댓글 수정 성공",
+  "code": "00",
+  "data": null
+}
+```
+
+```json
+// HTTP/1.1 400 BAD REQUEST
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "파라미터 형식에 맞지 않습니다",
+  "code": "11",
+  "data": {
+    "userId": "cheesecat$@"
+  }
+}
+```
+
+```json
+// HTTP/1.1 401 UNAUTHORIZED
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "댓글 수정은 작성자만 가능합니다",
+  "code": "12",
+  "data": {
+    "Authorization": "Bearer eyJ0eXAiOi...",
+    "userId": "rosielsh"
+  }
+}
+```
+
+### deleteComment 댓글 삭제
+
+- 댓글 삭제.
+
+```http request
+DELETE /api/post/:postId/comment/:commentId
+```
+
+#### 요청
+
+| Param Type |      Name       | Data Type | Required |                          Description                           |
+|:----------:|:---------------:|:---------:|:--------:|:--------------------------------------------------------------:|
+|    Path    |    `postId`     |   `int`   |    O     |                             글 아이디                              |
+|    Path    |   `commentId`   |   `int`   |    O     |                             댓글 아이디                             |
+|    Body    |    `userId`     | `String`  |    -     |                     유저 아이디. DB의 `id_str` 값                     |
+|   Header   | `Authorization` | `String`  |    -     |              액세스 토큰. `userId`를 사용해 작성한 댓글 삭제 시 필요              |
+|    Body    |   `tmpUserId`   | `String`  |    -     | 비회원으로 작성한 댓글 삭제 시 필요한 유저 아이디. `userId` 또는 이 값 중 하나 필수. 둘 다는 불가 |
+|    Body    |   `tmpUserPw`   | `String`  |    -     |            비회원 댓글 삭제 시 유저 비밀번호. `tmpUserId` 사용 시 필요            |
+
+##### 예시
+
+```bash
+curl -X 'DELETE' \
+  'http://localhost:8080/api/post/1/comment/1' \
+  -H 'accept: application/json;charset=utf-8' \
+  -H 'Authorization: Bearer eyJ0eXAiOi...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "userId": "cheesecat47",
+}'
+```
+
+
+#### 응답
+
+##### 예시
+
+```json
+// HTTP/1.1 204 NO CONTENT
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "댓글 삭제 성공",
+  "code": "00",
+  "data": null
+}
+```
+
+```json
+// HTTP/1.1 401 UNAUTHORIZED
+// Content-Type: application/json;charset=UTF-8
+{
+  "message": "댓글 삭제는 작성자만 가능합니다",
   "code": "12",
   "data": {
     "Authorization": "Bearer eyJ0eXAiOi...",


### PR DESCRIPTION
## 이슈

- #82

## 작업 사항

- 댓글 관련 API 명세 작성
- getCommentsByPostId 특정 글에 달린 댓글 목록 조회 명세 작성
  - 기존에 getPostById에 댓글 목록 조회가 포함되어 있었으나, 별개의 API로 분리
- updateBlogInfo 블로그 정보 변경 명세 작성

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.
