### PR TITLE
Fix: 게시판 아이디 -> 게시판 이름, 글 아이디 -> 글 제목 사용하도록 API 변경 

### DIFF
--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -945,20 +945,30 @@ curl -X 'GET' \
 }
 ```
 
-### getPostById 글 상세 조회
+### getPostByTitle 글 상세 조회
 
 - 글 상세 조회. 이 글과 연결된 댓글 포함.
 
 ```http request
-GET /api/post/:userId/:postId
+GET /api/post/:postTitle
 ```
 
 #### 요청
 
-| Param Type |   Name   | Data Type | Required | Description |
-|:----------:|:--------:|:---------:|:--------:|:-----------:|
-|    Path    | `userId` | `String`  |    O     |   유저 아이디    |
-|    Path    | `postId` |   `int`   |    O     |   게시글 아이디   |
+| Param Type |    Name     | Data Type | Required |        Description        |
+|:----------:|:-----------:|:---------:|:--------:|:-------------------------:|
+|    Path    | `postTitle` | `String`  |    O     | 글 제목. 공백 문자는 `-`로 치환하여 입력 |
+
+##### 예시
+
+```bash
+curl -X 'GET' \
+  'http://localhost:8080/api/post/Java-너무-재미있어요.' \
+  -H 'accept: application/json;charset=utf-8'
+
+# 본 예시에서는 `Java-너무-재미있어요.`로 보이나 실제 URL은 인코딩으로 인해 다음과 같음:
+# http://localhost:8080/api/post/Java-%EB%84%88%EB%AC%B4-%EC%9E%AC%EB%AF%B8%EC%9E%88%EC%96%B4%EC%9A%94.
+```
 
 #### 응답
 
@@ -1010,35 +1020,35 @@ GET /api/post/:userId/:postId
 // HTTP/1.1 200 OK
 // Content-Type: application/json;charset=UTF-8
 {
-  "message": "인기 글 목록 조회 성공",
-  "errors": null,
+  "message": "글 상세 조회 성공",
+  "code": "00",
   "data": {
-    "postId": 4,
+    "postId": 1,
     "categoryId": 1,
     "categoryName": "Java",
-    "title": "내 아이디가 왜 cheesecat이냐면",
+    "title": "Java 너무 재미있어요.",
     "author": {
       "userId": "cheesecat47",
       "nickName": "신주용",
       "profileImage": null
     },
-    "createdAt": "2023-12-02T23:00:00Z",
-    "hit": 21,
-    "excerpt": "2018년 10월에 동촌 유원지에 사진 찍으러 나갔다가 만난 아기 고양이. 진짜 예뻤다.",
-    "thumbnail": "...",
-    "content": "2018년 10월에 동촌 유원지에 사진 찍으러 나갔다가 만난 아기 고양이. 진짜 예뻤다. 사람을 경계는 하면서도 멀리 도망가지는 않고 웅크리고 앉아서 지켜보는데 얼마나 귀엽던지.",
+    "createdAt": "2024-01-17T10:57:15Z",
+    "hit": 5,
+    "excerpt": "...",
+    "thumbnail": null,
+    "content": null,
     "comments": [
       {
         "commentId": 2,
-        "userId": "cheesecat47",
-        "content": "그치? ㅋㅋㅋ",
-        "createdAt": "2023-12-02T23:02:00Z"
+        "userId": "1",
+        "content": "삭제된 댓글댓글!",
+        "createdAt": "2024-01-17T11:02:15Z"
       },
       {
         "commentId": 1,
         "userId": "rosielsh",
-        "content": "짱 귀여워!",
-        "createdAt": "2023-12-02T23:01:00Z"
+        "content": "댓글댓글!",
+        "createdAt": "2024-01-17T11:01:15Z"
       }
     ],
     "numOfComments": 2

--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -719,23 +719,23 @@ curl -X 'POST' \
 - 게시판 정보 변경.
 
 ```http request
-PUT /api/blog/:userId/category/:categoryId
+PUT /api/blog/:userId/category/:categoryName
 ```
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |                          Description                          |
-|:----------:|:---------------:|:---------:|:--------:|:-------------------------------------------------------------:|
-|    Path    |    `userId`     | `String`  |    O     |                    유저 아이디. DB의 `id_str` 값                     |
-|    Path    |  `categoryId`   |   `int`   |    O     |                       정보를 변경하려는 게시판 아이디                       |
-|   Header   | `Authorization` | `String`  |    O     |                  액세스 토큰. 본인 블로그 게시판 정보 변경 가능                  |
-|    Body    | `categoryName`  | `String`  |    O     |                           새 게시판 이름                            |
+| Param Type |      Name       | Data Type | Required |              Description              |
+|:----------:|:---------------:|:---------:|:--------:|:-------------------------------------:|
+|    Path    |    `userId`     | `String`  |    O     |        유저 아이디. DB의 `id_str` 값         |
+|    Path    | `categoryName`  | `String`  |    O     | 정보를 변경하려는 게시판 이름. 공백 문자는 `-`로 치환하여 입력 |
+|   Header   | `Authorization` | `String`  |    O     |      액세스 토큰. 본인 블로그 게시판 정보 변경 가능      |
+|    Body    | `categoryName`  | `String`  |    O     |               새 게시판 이름                |
 
 ##### 예시
 
 ```bash
 curl -X 'PUT' \
-  'http://localhost:8080/api/blog/cheesecat47/category/1' \
+  'http://localhost:8080/api/blog/cheesecat47/category/Spring-스터디' \
   -H 'accept: application/json;charset=utf-8' \
   -H 'Authorization: Bearer eyJ0eXAiOi...' \
   -H 'Content-Type: application/json' \
@@ -788,22 +788,22 @@ curl -X 'PUT' \
 - 게시판 삭제
 
 ```http request
-DELETE /api/blog/:userId/category/:categoryId
+DELETE /api/blog/:userId/category/:categoryName
 ```
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |                        Description                         |
-|:----------:|:---------------:|:---------:|:--------:|:----------------------------------------------------------:|
-|    Path    |    `userId`     | `String`  |    O     |                   유저 아이디. DB의 `id_str` 값                   |
-|    Path    |  `categoryId`   |   `int`   |    O     |                       삭제하려는 게시판 아이디                        |
-|   Header   | `Authorization` | `String`  |    O     |                  액세스 토큰. 본인 블로그 게시판 삭제 가능                  |
+| Param Type |      Name       | Data Type | Required |            Description            |
+|:----------:|:---------------:|:---------:|:--------:|:---------------------------------:|
+|    Path    |    `userId`     | `String`  |    O     |      유저 아이디. DB의 `id_str` 값       |
+|    Path    | `categoryName`  | `String`  |    O     | 삭제하려는 게시판 이름. 공백 문자는 `-`로 치환하여 입력 |
+|   Header   | `Authorization` | `String`  |    O     |     액세스 토큰. 본인 블로그 게시판 삭제 가능      |
 
 ##### 예시
 
 ```bash
 curl -X 'DELETE' \
-  'http://localhost:8080/api/blog/cheesecat47/category/1' \
+  'http://localhost:8080/api/blog/cheesecat47/category/Spring-스터디' \
   -H 'accept: application/json;charset=utf-8' \
   -H 'Authorization: Bearer eyJ0eXAiOi...' \
   -H 'Content-Type: application/json'
@@ -1082,7 +1082,7 @@ POST /api/post
 |:----------:|:---------------:|:---------:|:--------:|:-----------------------:|
 |   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 글 작성 가능  |
 |    Body    |    `userId`     | `String`  |    O     | 유저 아이디. DB의 `id_str` 값  |
-|    Body    |  `categoryId`   |   `int`   |    O     |         게시판 아이디         |
+|    Body    | `categoryName`  | `String`  |    O     |         게시판 이름          |
 |    Body    |     `title`     | `String`  |    O     |          글 제목           |
 |    Body    |    `excerpt`    | `String`  |    -     | 글 요약. 최대 200자. 기본값 `""` |
 |    Body    |    `content`    | `String`  |    -     |     글 본문. 최대 2000자      |
@@ -1097,7 +1097,7 @@ curl -X 'POST' \
   -H 'Content-Type: application/json' \
   -d '{
   "userId": "cheesecat47",
-  "categoryId": 1,
+  "categoryName": "Spring 스터디",
   "title": "Spring 공부 중",
   "content": "스프링 공부 중인데 재밌다. 이케이케 하면 서버가 실행된다."
 }'
@@ -1147,26 +1147,26 @@ curl -X 'POST' \
 - 글 수정.
 
 ```http request
-PUT /api/post/:postId
+PUT /api/post/:postTitle
 ```
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |       Description       |
-|:----------:|:---------------:|:---------:|:--------:|:-----------------------:|
-|   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 글 수정 가능  |
-|    Path    |    `postId`     |   `int`   |    O     |        수정할 글 아이디        |
-|    Body    |    `userId`     | `String`  |    O     | 유저 아이디. DB의 `id_str` 값  |
-|    Body    |  `categoryId`   |   `int`   |    -     |         게시판 아이디         |
-|    Body    |     `title`     | `String`  |    -     |          글 제목           |
-|    Body    |    `excerpt`    | `String`  |    -     | 글 요약. 최대 200자. 기본값 `""` |
-|    Body    |    `content`    | `String`  |    -     |     글 본문. 최대 2000자      |
+| Param Type |      Name       | Data Type | Required |          Description          |
+|:----------:|:---------------:|:---------:|:--------:|:-----------------------------:|
+|   Header   | `Authorization` | `String`  |    O     |    액세스 토큰. 본인 블로그 글 수정 가능     |
+|    Path    |   `postTitle`   | `String`  |    O     | 수정할 글 제목. 공백 문자는 `-`로 치환하여 입력 |
+|    Body    |    `userId`     | `String`  |    O     |    유저 아이디. DB의 `id_str` 값     |
+|    Body    | `categoryName`  | `String`  |    -     |            게시판 이름             |
+|    Body    |     `title`     | `String`  |    -     |             글 제목              |
+|    Body    |    `excerpt`    | `String`  |    -     |    글 요약. 최대 200자. 기본값 `""`    |
+|    Body    |    `content`    | `String`  |    -     |        글 본문. 최대 2000자         |
 
 ##### 예시
 
 ```bash
 curl -X 'PUT' \
-  'http://localhost:8080/api/post/1' \
+  'http://localhost:8080/api/post/Spring-공부-중' \
   -H 'accept: application/json;charset=utf-8' \
   -H 'Authorization: Bearer eyJ0eXAiOi...' \
   -H 'Content-Type: application/json' \
@@ -1220,22 +1220,22 @@ curl -X 'PUT' \
 - 글 삭제.
 
 ```http request
-DELETE /api/post/:postId
+DELETE /api/post/:postTitle
 ```
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |       Description       |
-|:----------:|:---------------:|:---------:|:--------:|:-----------------------:|
-|   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 글 수정 가능  |
-|    Path    |    `postId`     |   `int`   |    O     |        수정할 글 아이디        |
-|    Body    |    `userId`     | `String`  |    O     | 유저 아이디. DB의 `id_str` 값  |
+| Param Type |      Name       | Data Type | Required |          Description          |
+|:----------:|:---------------:|:---------:|:--------:|:-----------------------------:|
+|   Header   | `Authorization` | `String`  |    O     |    액세스 토큰. 본인 블로그 글 수정 가능     |
+|    Path    |   `postTitle`   | `String`  |    O     | 삭제할 글 제목. 공백 문자는 `-`로 치환하여 입력 |
+|    Body    |    `userId`     | `String`  |    O     |    유저 아이디. DB의 `id_str` 값     |
 
 ##### 예시
 
 ```bash
 curl -X 'DELETE' \
-  'http://localhost:8080/api/post/1' \
+  'http://localhost:8080/api/post/Spring-공부-중' \
   -H 'accept: application/json;charset=utf-8' \
   -H 'Authorization: Bearer eyJ0eXAiOi...' \
   -H 'Content-Type: application/json' \

--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -845,18 +845,29 @@ curl -X 'DELETE' \
 - 조건에 일치하는 글 목록 조회
 
 ```http request
-GET /api/post?userId=&categoryId=&order=recent&offset=0&limit=10
+GET /api/post?userId=&categoryName=&order=recent&offset=0&limit=10
 ```
 
 #### 요청
 
-| Param Type |     Name     | Data Type | Required |                           Description                            |  
-|:----------:|:------------:|:---------:|:--------:|:----------------------------------------------------------------:|
-|   Query    |   `userId`   | `String`  |    -     |                              유저 아이디                              |
-|   Query    | `categoryId` |   `int`   |    -     |          게시판 아이디. 특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록          |
-|   Query    |   `order`    | `String`  |    -     | `latest(최신순)`,`oldest(오래된순)`,`popular(인기순)` 중 택 1. 기본값은 `latest` |
-|   Query    |   `offset`   |   `int`   |    -     |                  정렬된 결과 중 `offset`부터 반환. 기본값 0                   |
-|   Query    |   `limit`    |   `int`   |    -     |                  `offset`부터 `limit`개 조회. 기본값 10                  |
+| Param Type |      Name      | Data Type | Required |                               Description                                |  
+|:----------:|:--------------:|:---------:|:--------:|:------------------------------------------------------------------------:|
+|   Query    |    `userId`    | `String`  |    -     |                                  유저 아이디                                  |
+|   Query    | `categoryName` | `String`  |    -     |  게시판 이름. 공백 문자는 `-`로 치환하여 입력.<br/>특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록  |
+|   Query    |    `order`     | `String`  |    -     | 정렬 방법. `latest(최신순)`,`oldest(오래된순)`,`popular(인기순)` 중 택 1. 기본 값은 `latest` |
+|   Query    |    `offset`    |   `int`   |    -     |                      정렬된 결과 중 `offset`부터 반환. 기본값 0                       |
+|   Query    |    `limit`     |   `int`   |    -     |                      `offset`부터 `limit`개 조회. 기본값 10                      |
+
+##### 예시
+
+```bash
+curl -X 'GET' \
+  'http://localhost:8080/api/post?categoryName=알고리즘-문제&order=popular' \
+  -H 'accept: application/json;charset=utf-8'
+
+# 본 예시에서는 `알고리즘-문제`로 보이나 실제 URL은 인코딩으로 인해 다음과 같음:
+# http://localhost:8080/api/post?categoryName=%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EB%AC%B8%EC%A0%9C&order=popular
+```
 
 #### 응답
 
@@ -897,26 +908,27 @@ GET /api/post?userId=&categoryId=&order=recent&offset=0&limit=10
 // HTTP/1.1 200 OK
 // Content-Type: application/json;charset=UTF-8
 {
-  "message": "NORMAL_SERVICE",
+  "message": "글 목록 조회 성공",
   "code": "00",
   "data": [
     {
       "postId": 4,
-      "categoryId": 1,
-      "categoryName": "Java",
-      "title": "내 아이디가 왜 cheesecat이냐면",
+      "categoryId": 4,
+      "categoryName": "알고리즘 문제",
+      "title": "알고리즘 쉽지 않네요.",
       "author": {
         "userId": "cheesecat47",
         "nickName": "신주용",
         "profileImage": null
       },
-      "createdAt": "2023-12-02T23:00:00Z",
-      "hit": 21,
-      "excerpt": "2018년 10월에 동촌 유원지에 사진 찍으러 나갔다가 만난 아기 고양이. 진짜 예뻤다.",
-      "thumbnail": "...",
-      "numOfComments": 2
-    },
-    ...
+      "createdAt": "2024-01-17T11:00:15Z",
+      "hit": 5,
+      "excerpt": "...",
+      "thumbnail": null,
+      "content": null,
+      "comments": null,
+      "numOfComments": 0
+    }
   ]
 }
 ```
@@ -925,8 +937,8 @@ GET /api/post?userId=&categoryId=&order=recent&offset=0&limit=10
 // HTTP/1.1 400 BAD REQUEST
 // Content-Type: application/json;charset=UTF-8
 {
-  "message": "INVALID_REQUEST_PARAMETER",
-  "code": "11",
+  "message": "입력한 아이디에 해당하는 유저가 없습니다",
+  "code": "13",
   "data": {
     "userId": "cheesecat$&"
   }

--- a/docs/API-spec.md
+++ b/docs/API-spec.md
@@ -792,12 +792,12 @@ PUT /api/blog/:userId/category/:categoryName
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |              Description              |
-|:----------:|:---------------:|:---------:|:--------:|:-------------------------------------:|
-|    Path    |    `userId`     | `String`  |    O     |        유저 아이디. DB의 `id_str` 값         |
-|    Path    | `categoryName`  | `String`  |    O     | 정보를 변경하려는 게시판 이름. 공백 문자는 `-`로 치환하여 입력 |
-|   Header   | `Authorization` | `String`  |    O     |      액세스 토큰. 본인 블로그 게시판 정보 변경 가능      |
-|    Body    | `categoryName`  | `String`  |    O     |               새 게시판 이름                |
+| Param Type |      Name       | Data Type | Required |         Description         |
+|:----------:|:---------------:|:---------:|:--------:|:---------------------------:|
+|    Path    |    `userId`     | `String`  |    O     |   유저 아이디. DB의 `id_str` 값    |
+|    Path    | `categoryName`  | `String`  |    O     |      정보를 변경하려는 게시판 이름       |
+|   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 게시판 정보 변경 가능 |
+|    Body    | `categoryName`  | `String`  |    O     |          새 게시판 이름           |
 
 ##### 예시
 
@@ -861,11 +861,11 @@ DELETE /api/blog/:userId/category/:categoryName
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |            Description            |
-|:----------:|:---------------:|:---------:|:--------:|:---------------------------------:|
-|    Path    |    `userId`     | `String`  |    O     |      유저 아이디. DB의 `id_str` 값       |
-|    Path    | `categoryName`  | `String`  |    O     | 삭제하려는 게시판 이름. 공백 문자는 `-`로 치환하여 입력 |
-|   Header   | `Authorization` | `String`  |    O     |     액세스 토큰. 본인 블로그 게시판 삭제 가능      |
+| Param Type |      Name       | Data Type | Required |       Description        |
+|:----------:|:---------------:|:---------:|:--------:|:------------------------:|
+|    Path    |    `userId`     | `String`  |    O     |  유저 아이디. DB의 `id_str` 값  |
+|    Path    | `categoryName`  | `String`  |    O     |       삭제하려는 게시판 이름       |
+|   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 게시판 삭제 가능 |
 
 ##### 예시
 
@@ -921,7 +921,7 @@ GET /api/post?userId=&categoryName=&order=recent&offset=0&limit=10
 | Param Type |      Name      | Data Type | Required |                               Description                                |  
 |:----------:|:--------------:|:---------:|:--------:|:------------------------------------------------------------------------:|
 |   Query    |    `userId`    | `String`  |    -     |                                  유저 아이디                                  |
-|   Query    | `categoryName` | `String`  |    -     |  게시판 이름. 공백 문자는 `-`로 치환하여 입력.<br/>특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록  |
+|   Query    | `categoryName` | `String`  |    -     |             게시판 이름<br/>특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록             |
 |   Query    |    `order`     | `String`  |    -     | 정렬 방법. `latest(최신순)`,`oldest(오래된순)`,`popular(인기순)` 중 택 1. 기본 값은 `latest` |
 |   Query    |    `offset`    |   `int`   |    -     |                      정렬된 결과 중 `offset`부터 반환. 기본값 0                       |
 |   Query    |    `limit`     |   `int`   |    -     |                      `offset`부터 `limit`개 조회. 기본값 10                      |
@@ -1023,9 +1023,9 @@ GET /api/post/:postTitle
 
 #### 요청
 
-| Param Type |    Name     | Data Type | Required |        Description        |
-|:----------:|:-----------:|:---------:|:--------:|:-------------------------:|
-|    Path    | `postTitle` | `String`  |    O     | 글 제목. 공백 문자는 `-`로 치환하여 입력 |
+| Param Type |    Name     | Data Type | Required | Description |
+|:----------:|:-----------:|:---------:|:--------:|:-----------:|
+|    Path    | `postTitle` | `String`  |    O     |    글 제목     |
 
 ##### 예시
 
@@ -1194,15 +1194,15 @@ PUT /api/post/:postTitle
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |          Description          |
-|:----------:|:---------------:|:---------:|:--------:|:-----------------------------:|
-|   Header   | `Authorization` | `String`  |    O     |    액세스 토큰. 본인 블로그 글 수정 가능     |
-|    Path    |   `postTitle`   | `String`  |    O     | 수정할 글 제목. 공백 문자는 `-`로 치환하여 입력 |
-|    Body    |    `userId`     | `String`  |    O     |    유저 아이디. DB의 `id_str` 값     |
-|    Body    | `categoryName`  | `String`  |    -     |            게시판 이름             |
-|    Body    |     `title`     | `String`  |    -     |             글 제목              |
-|    Body    |    `excerpt`    | `String`  |    -     |    글 요약. 최대 200자. 기본값 `""`    |
-|    Body    |    `content`    | `String`  |    -     |        글 본문. 최대 2000자         |
+| Param Type |      Name       | Data Type | Required |       Description       |
+|:----------:|:---------------:|:---------:|:--------:|:-----------------------:|
+|   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 글 수정 가능  |
+|    Path    |   `postTitle`   | `String`  |    O     |        수정할 글 제목         |
+|    Body    |    `userId`     | `String`  |    O     | 유저 아이디. DB의 `id_str` 값  |
+|    Body    | `categoryName`  | `String`  |    -     |         게시판 이름          |
+|    Body    |     `title`     | `String`  |    -     |          글 제목           |
+|    Body    |    `excerpt`    | `String`  |    -     | 글 요약. 최대 200자. 기본값 `""` |
+|    Body    |    `content`    | `String`  |    -     |     글 본문. 최대 2000자      |
 
 ##### 예시
 
@@ -1267,11 +1267,11 @@ DELETE /api/post/:postTitle
 
 #### 요청
 
-| Param Type |      Name       | Data Type | Required |          Description          |
-|:----------:|:---------------:|:---------:|:--------:|:-----------------------------:|
-|   Header   | `Authorization` | `String`  |    O     |    액세스 토큰. 본인 블로그 글 수정 가능     |
-|    Path    |   `postTitle`   | `String`  |    O     | 삭제할 글 제목. 공백 문자는 `-`로 치환하여 입력 |
-|    Body    |    `userId`     | `String`  |    O     |    유저 아이디. DB의 `id_str` 값     |
+| Param Type |      Name       | Data Type | Required |      Description       |
+|:----------:|:---------------:|:---------:|:--------:|:----------------------:|
+|   Header   | `Authorization` | `String`  |    O     | 액세스 토큰. 본인 블로그 글 수정 가능 |
+|    Path    |   `postTitle`   | `String`  |    O     |        삭제할 글 제목        |
+|    Body    |    `userId`     | `String`  |    O     | 유저 아이디. DB의 `id_str` 값 |
 
 ##### 예시
 

--- a/myBlog-api/resources/sql/04.category-post-unique.sql
+++ b/myBlog-api/resources/sql/04.category-post-unique.sql
@@ -1,0 +1,6 @@
+use myBlog;
+
+alter table Category
+    add unique (name);
+alter table Post
+    add unique (title);

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
@@ -45,14 +45,15 @@ public class PostController {
     @GetMapping(value = "")
     public ResponseEntity<GetPostsResponse> getPosts(
             @Parameter(description = "유저 아이디") @RequestParam(required = false) String userId,
-            @Parameter(description = "게시판 아이디") @RequestParam(required = false) String categoryId,
+            @Parameter(description = "게시판 이름") @RequestParam(required = false) String categoryName,
             @Parameter(description = "정렬 방법") @RequestParam(required = false, defaultValue = "latest") String order,
             @Parameter(description = "offset: 몇 번째 글부터") @RequestParam(required = false, defaultValue = "0") String offset,
             @Parameter(description = "limit: 몇 개의 글 조회 할지") @RequestParam(required = false, defaultValue = "10") String limit
     ) throws Exception {
         GetPostsRequest params = new GetPostsRequest();
         params.setUserId(userId);
-        params.setCategoryId(categoryId == null ? 0 : Integer.parseInt(categoryId));
+        // 게시판 이름이 `알고리즘 문제`라면 파라미터에 `알고리즘-문제`와 같이 들어오므로 치환 필요
+        params.setCategoryName(categoryName.replace('-', ' '));
         params.setOrder(order);
         params.setOffset(Integer.parseInt(offset));
         params.setLimit(Integer.parseInt(limit));

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
@@ -52,8 +52,7 @@ public class PostController {
     ) throws Exception {
         GetPostsRequest params = new GetPostsRequest();
         params.setUserId(userId);
-        // 게시판 이름이 `알고리즘 문제`라면 파라미터에 `알고리즘-문제`와 같이 들어오므로 치환 필요
-        params.setCategoryName(categoryName.replace('-', ' '));
+        params.setCategoryName(categoryName);
         params.setOrder(order);
         params.setOffset(Integer.parseInt(offset));
         params.setLimit(Integer.parseInt(limit));
@@ -81,9 +80,8 @@ public class PostController {
     })
     @GetMapping(value = "/{postTitle}")
     public ResponseEntity<GetPostByTitleResponse> getPostByTitle(
-            @Parameter(description = "글 제목. 공백 문자는 `-`로 치환하여 입력") @PathVariable String postTitle
+            @Parameter(description = "글 제목") @PathVariable String postTitle
     ) throws Exception {
-        postTitle = postTitle.replace('-', ' ');
         log.debug("getPostByTitle: postTitle: {}", postTitle);
 
         GetPostByTitleResponse response = new GetPostByTitleResponse();

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
@@ -3,7 +3,7 @@ package com.github.cheesecat47.myBlog.post.controller;
 import com.github.cheesecat47.myBlog.common.exception.ResponseCode;
 import com.github.cheesecat47.myBlog.post.model.PostDto;
 import com.github.cheesecat47.myBlog.post.model.request.GetPostsRequest;
-import com.github.cheesecat47.myBlog.post.model.response.GetPostByIdResponse;
+import com.github.cheesecat47.myBlog.post.model.response.GetPostByTitleResponse;
 import com.github.cheesecat47.myBlog.post.model.response.GetPostsResponse;
 import com.github.cheesecat47.myBlog.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,27 +72,26 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "getPostById 글 상세 조회", description = "글 상세 조회. 이 글과 연결된 댓글 포함.")
+    @Operation(summary = "getPostByTitle 글 상세 조회", description = "글 상세 조회. 이 글과 연결된 댓글 포함.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "글 조회 성공", content = {@Content(schema = @Schema(implementation = GetPostsResponse.class))}),
+            @ApiResponse(responseCode = "200", description = "글 조회 성공", content = {@Content(schema = @Schema(implementation = GetPostByTitleResponse.class))}),
             @ApiResponse(responseCode = "400", description = "글 조회 실패"),
             @ApiResponse(responseCode = "404", description = "글 조회 실패"),
             @ApiResponse(responseCode = "500", description = "글 조회 실패")
     })
-    @GetMapping(value = "/{userId}/{postId}")
-    public ResponseEntity<GetPostByIdResponse> getPostById(
-            @Parameter(description = "유저 아이디") @PathVariable String userId,
-            @Parameter(description = "글 아이디") @PathVariable String postId
+    @GetMapping(value = "/{postTitle}")
+    public ResponseEntity<GetPostByTitleResponse> getPostByTitle(
+            @Parameter(description = "글 제목. 공백 문자는 `-`로 치환하여 입력") @PathVariable String postTitle
     ) throws Exception {
-        log.debug("getPostById: userId: {}", userId);
-        log.debug("getPostById: postId: {}", postId);
+        postTitle = postTitle.replace('-', ' ');
+        log.debug("getPostByTitle: postTitle: {}", postTitle);
 
-        GetPostByIdResponse response = new GetPostByIdResponse();
+        GetPostByTitleResponse response = new GetPostByTitleResponse();
 
-        PostDto postDto = postService.getPostById(userId, postId);
+        PostDto postDto = postService.getPostByTitle(postTitle);
 
         String msg = "글 상세 조회 성공";
-        log.info("getPostById: {}", msg);
+        log.info("getPostByTitle: {}", msg);
         response.setCode(ResponseCode.NORMAL_SERVICE);
         response.setMessage(msg);
         response.setData(postDto);

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/mapper/PostMapper.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/mapper/PostMapper.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface PostMapper {
     List<PostDto> getPosts(GetPostsRequest params) throws SQLException;
 
-    PostDto getPostById(String userId, String postId) throws SQLException;
+    PostDto getPostByTitle(String postTitle) throws SQLException;
 }

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/request/GetPostsRequest.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/request/GetPostsRequest.java
@@ -8,7 +8,7 @@ public class GetPostsRequest {
     @Schema(description = "유저 아이디.")
     String userId;
 
-    @Schema(description = "게시판 이름. 공백 문자는 -로 치환하여 입력.<br/>특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록")
+    @Schema(description = "게시판 이름.<br/>특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록")
     String categoryName;
 
     @Schema(description = "latest(최신순), oldest(오래된순), popular(인기순) 중 택 1. 기본값은 latest")

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/request/GetPostsRequest.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/request/GetPostsRequest.java
@@ -8,8 +8,8 @@ public class GetPostsRequest {
     @Schema(description = "유저 아이디.")
     String userId;
 
-    @Schema(description = "게시판 아이디. 특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록.")
-    int categoryId;
+    @Schema(description = "게시판 이름. 공백 문자는 -로 치환하여 입력.<br/>특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록")
+    String categoryName;
 
     @Schema(description = "latest(최신순), oldest(오래된순), popular(인기순) 중 택 1. 기본값은 latest")
     String order;

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/response/GetPostByTitleResponse.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/response/GetPostByTitleResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-public class GetPostByIdResponse {
+public class GetPostByTitleResponse {
     @Schema(description = "응답 코드. API 명세서 참고")
     String code;
 

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostService.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface PostService {
     List<PostDto> getPosts(GetPostsRequest params) throws Exception;
 
-    PostDto getPostById(String userId, String postId) throws Exception;
+    PostDto getPostByTitle(String postTitle) throws Exception;
 }

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostServiceImpl.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostServiceImpl.java
@@ -65,32 +65,18 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostDto getPostById(String userId, String postId) throws Exception {
-        log.debug("getPostById: userId: {}", userId);
-        log.debug("getPostById: postId: {}", postId);
+    public PostDto getPostByTitle(String postTitle) throws Exception {
+        log.debug("getPostByTitle: postTitle: {}", postTitle);
 
         // 공백인 경우
-        if (userId.isEmpty() || userId.isBlank()) {
-            String msg = "유저 아이디는 필수입니다";
-            log.error("getPostById: {}", msg);
+        if (postTitle.isEmpty() || postTitle.isBlank()) {
+            String msg = "글 제목은 필수입니다";
+            log.error("getPostByTitle: {}", msg);
             throw new MyBlogCommonException(
                     ResponseCode.NO_REQUIRED_REQUEST_PARAMETER,
                     msg,
                     new HashMap<>() {{
-                        put("userId", userId);
-                    }}
-            );
-        }
-
-        // 공백인 경우
-        if (postId.isEmpty() || postId.isBlank()) {
-            String msg = "글 아이디는 필수입니다";
-            log.error("getPostById: {}", msg);
-            throw new MyBlogCommonException(
-                    ResponseCode.NO_REQUIRED_REQUEST_PARAMETER,
-                    msg,
-                    new HashMap<>() {{
-                        put("postId", postId);
+                        put("postTitle", postTitle);
                     }}
             );
         }
@@ -98,30 +84,16 @@ public class PostServiceImpl implements PostService {
         // DB에서 조회
         PostDto postDto;
         try {
-            // 존재하는 유저인지 확인
-            UserInfoDto userInfoDto = userMapper.getUserInfo(userId);
-            if (userInfoDto == null) {
-                String msg = "입력한 아이디에 해당하는 유저가 없습니다";
-                log.error("getPostById: {}", msg);
-                throw new MyBlogCommonException(
-                        ResponseCode.NO_RESULT,
-                        msg,
-                        new HashMap<>() {{
-                            put("userId", userId);
-                        }}
-                );
-            }
-
             // 존재하는 글인지 확인
-            postDto = postMapper.getPostById(userId, postId);
+            postDto = postMapper.getPostByTitle(postTitle);
             if (postDto == null) {
                 String msg = "해당하는 글이 없습니다";
-                log.error("getPostById: {}", msg);
+                log.error("getPostByTitle: {}", msg);
                 throw new MyBlogCommonException(
                         ResponseCode.NO_RESULT,
                         msg,
                         new HashMap<>() {{
-                            put("postId", postId);
+                            put("postTitle", postTitle);
                         }}
                 );
             }
@@ -129,16 +101,15 @@ public class PostServiceImpl implements PostService {
             // 댓글 개수 업데이트
             postDto.setNumOfComments(postDto.getComments().size());
 
-            log.debug("getPostById: postDto: {}", postDto);
+            log.debug("getPostByTitle: postDto: {}", postDto);
         } catch (SQLException e) {
             String msg = "DB 조회 중 오류가 발생했습니다";
-            log.error("getPostById: {}", msg);
+            log.error("getPostByTitle: {}", msg);
             throw new MyBlogCommonException(
                     ResponseCode.SQL_ERROR,
                     msg,
                     new HashMap<>() {{
-                        put("userId", userId);
-                        put("postId", postId);
+                        put("postTitle", postTitle);
                         put("error", e.getMessage());
                     }}
             );

--- a/myBlog-api/src/main/resources/mapper/post.xml
+++ b/myBlog-api/src/main/resources/mapper/post.xml
@@ -59,8 +59,8 @@
         limit #{offset}, #{limit};
     </select>
 
-    <!--  getPostById 결과 매핑 -->
-    <resultMap id="getPostByIdResultMap" type="PostDto">
+    <!--  getPostByTitle 결과 매핑 -->
+    <resultMap id="getPostByTitleResultMap" type="PostDto">
         <result property="postId" column="post_id"/>
         <result property="categoryId" column="category_id"/>
         <result property="categoryName" column="category_name"/>
@@ -81,8 +81,8 @@
         </collection>
     </resultMap>
 
-    <!--  getPostById 쿼리 -->
-    <select id="getPostById" parameterType="String" resultMap="getPostByIdResultMap">
+    <!--  getPostByTitle 쿼리 -->
+    <select id="getPostByTitle" parameterType="String" resultMap="getPostByTitleResultMap">
         select Post.id                                                        as post_id,
                Post.category_id,
                Category.name                                                  as category_name,
@@ -101,9 +101,7 @@
                  left outer join myBlog.User on Post.user_id = User.id
                  left outer join myBlog.Category on Post.category_id = Category.id
                  left outer join myBlog.Comment on Comment.post_id = Post.id
-        where myBlog.User.id_str = #{userId}
-          and Post.id = #{postId}
-          and User.deleted_at is null
+        where Post.title = #{postTitle}
           and Post.deleted_at is null
         order by comment_created_at desc;
     </select>

--- a/myBlog-api/src/main/resources/mapper/post.xml
+++ b/myBlog-api/src/main/resources/mapper/post.xml
@@ -43,8 +43,8 @@
           <if test="userId != null">
               and myBlog.User.id_str = #{userId}
           </if>
-          <if test="categoryId > 0">
-            and Category.id = #{categoryId}
+          <if test="categoryName != null">
+            and Category.name = #{categoryName}
           </if>
         order by
           <if test="order == 'latest'">


### PR DESCRIPTION
## 이슈

- #84

## 작업 사항

- 동일한 게시판 이름이나 제목이 없도록 Category.name, Post.title에 Unique 제약조건 추가
- API 명세 수정
- 엔드포인트 파라미터 수정

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.
