### PR TITLE
Fix: 요청 파라미터 DTO 사용하도록 변경  

### DIFF
--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/controller/PostController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,18 +45,8 @@ public class PostController {
     })
     @GetMapping(value = "")
     public ResponseEntity<GetPostsResponse> getPosts(
-            @Parameter(description = "유저 아이디") @RequestParam(required = false) String userId,
-            @Parameter(description = "게시판 아이디") @RequestParam(required = false) String categoryId,
-            @Parameter(description = "정렬 방법") @RequestParam(required = false, defaultValue = "latest") String order,
-            @Parameter(description = "offset: 몇 번째 글부터") @RequestParam(required = false, defaultValue = "0") String offset,
-            @Parameter(description = "limit: 몇 개의 글 조회 할지") @RequestParam(required = false, defaultValue = "10") String limit
+            @ParameterObject GetPostsRequest params
     ) throws Exception {
-        GetPostsRequest params = new GetPostsRequest();
-        params.setUserId(userId);
-        params.setCategoryId(categoryId == null ? 0 : Integer.parseInt(categoryId));
-        params.setOrder(order);
-        params.setOffset(Integer.parseInt(offset));
-        params.setLimit(Integer.parseInt(limit));
         log.debug("getPosts: params: {}", params);
 
         GetPostsResponse response = new GetPostsResponse();

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/request/GetPostsRequest.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/request/GetPostsRequest.java
@@ -11,12 +11,12 @@ public class GetPostsRequest {
     @Schema(description = "게시판 아이디. 특정 게시판에 속한 글만 필터링 할 때 사용. 없으면 전체 글 목록.")
     int categoryId;
 
-    @Schema(description = "latest(최신순), oldest(오래된순), popular(인기순) 중 택 1. 기본값은 latest")
-    String order;
+    @Schema(description = "`latest(최신순)`, `oldest(오래된순)`, `popular(인기순)` 중 택 1. 기본 값은 `latest`", defaultValue = "latest")
+    String order = "latest";
 
-    @Schema(description = "정렬된 결과 중 offset부터 반환. 기본값 0")
-    int offset;
+    @Schema(description = "정렬된 결과 중 offset부터 반환. 기본값 0", defaultValue = "0")
+    int offset = 0;
 
-    @Schema(description = "offset부터 limit개 조회. 기본값 10")
-    int limit;
+    @Schema(description = "offset부터 limit개 조회. 기본값 10", defaultValue = "10")
+    int limit = 10;
 }

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/user/controller/UserController.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/user/controller/UserController.java
@@ -27,8 +27,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 /**
  * 유저 컨트롤러
  *
@@ -58,7 +56,7 @@ public class UserController {
     })
     @GetMapping(value = "/{userId}")
     public ResponseEntity<GetUserInfoResponse> getUserInfo(
-            @Parameter(description = "유저 아이디") @PathVariable Optional<String> userId
+            @Parameter(description = "유저 아이디") @PathVariable String userId
     ) throws Exception {
         log.debug("getUserInfo: userId: {}", userId);
 

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/user/service/UserService.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/user/service/UserService.java
@@ -6,10 +6,8 @@ import com.github.cheesecat47.myBlog.user.model.request.LoginRequestDto;
 import com.github.cheesecat47.myBlog.user.model.request.LogoutRequestDto;
 import com.github.cheesecat47.myBlog.user.model.request.RefreshRequestDto;
 
-import java.util.Optional;
-
 public interface UserService {
-    UserInfoDto getUserInfo(Optional<String> userId) throws Exception;
+    UserInfoDto getUserInfo(String userId) throws Exception;
 
     AuthTokenDto login(LoginRequestDto params) throws Exception;
 

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/user/service/UserServiceImpl.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/user/service/UserServiceImpl.java
@@ -35,7 +35,7 @@ public class UserServiceImpl implements UserService {
      * @throws MyBlogCommonException 입력 받은 유저 아이디에 문제가 있는 경우 발생.
      */
     @Override
-    public UserInfoDto getUserInfo(Optional<String> userId) throws Exception {
+    public UserInfoDto getUserInfo(String userId) throws Exception {
         log.debug("getUserInfo: userId: {}", userId);
 
         // 입력한 아이디가 없는 경우
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService {
         // DB에서 유저 조회
         UserInfoDto userInfoDto;
         try {
-            userInfoDto = userMapper.getUserInfo(userId.get());
+            userInfoDto = userMapper.getUserInfo(userId);
             log.debug("getUserInfo: userInfo: {}", userInfoDto);
 
             // 조회된 유저가 없는 경우


### PR DESCRIPTION
## 이슈

- #86

## 작업 사항

- getPosts에 쿼리 파라미터가 많았는데, 일일이 선언해서 코드가 길어지고 보기 힘들었음.
- DTO로 바꾸고 `@ParameterObject` 어노테이션을 사용해 Swagger에서 잘 보이도록 변경
- getUserInfo 파라미터를 다른 API와 통일하여 Optional이 아닌 일반 String으로 변경

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.
