### PR TITLE
Fix: 글 조회 시 댓글 내용 조회 분리

### DIFF
--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/PostDto.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/model/PostDto.java
@@ -3,8 +3,6 @@ package com.github.cheesecat47.myBlog.post.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 @Schema(description = "글 정보 객체.")
 public class PostDto {
@@ -37,9 +35,6 @@ public class PostDto {
 
     @Schema(description = "글 본문.")
     String content;
-
-    @Schema(description = "댓글 목록.")
-    List<CommentDto> comments;
 
     @Schema(description = "댓글 개수.")
     int numOfComments;

--- a/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostServiceImpl.java
+++ b/myBlog-api/src/main/java/com/github/cheesecat47/myBlog/post/service/PostServiceImpl.java
@@ -98,9 +98,6 @@ public class PostServiceImpl implements PostService {
                 );
             }
 
-            // 댓글 개수 업데이트
-            postDto.setNumOfComments(postDto.getComments().size());
-
             log.debug("getPostByTitle: postDto: {}", postDto);
         } catch (SQLException e) {
             String msg = "DB 조회 중 오류가 발생했습니다";

--- a/myBlog-api/src/main/resources/mapper/post.xml
+++ b/myBlog-api/src/main/resources/mapper/post.xml
@@ -4,8 +4,17 @@
 
 <mapper namespace="com.github.cheesecat47.myBlog.post.model.mapper.PostMapper">
 
-    <!--  getPosts 결과 매핑 -->
-    <resultMap id="getPostsResultMap" type="PostDto">
+    <!-- 댓글 개수 세는 쿼리문 공통으로 사용되므로 분리 -->
+    <sql id="getNumOfComments">
+        select count(*)
+        from Comment c,
+             User u
+        where c.post_id = Post.id
+          and u.id = User.id
+    </sql>
+
+    <!--  PostDto도 공통으로 사용되므로 분리 -->
+    <resultMap id="PostDtoMap" type="PostDto">
         <result property="postId" column="id"/>
         <result property="categoryId" column="category_id"/>
         <result property="categoryName" column="category_name"/>
@@ -13,6 +22,7 @@
         <result property="createdAt" column="created_at"/>
         <result property="hit" column="hit"/>
         <result property="excerpt" column="excerpt"/>
+        <result property="content" column="content"/>
         <result property="numOfComments" column="num_of_comments"/>
         <association property="author" column="author" javaType="AuthorDto">
             <result property="userId" column="id_str"/>
@@ -21,21 +31,17 @@
     </resultMap>
 
     <!--  getPosts 쿼리 -->
-    <select id="getPosts" parameterType="GetPostsRequest" resultMap="getPostsResultMap">
+    <select id="getPosts" parameterType="GetPostsRequest" resultMap="PostDtoMap">
         select Post.id,
                Post.category_id,
                Category.name                                                  as category_name,
                Post.title,
                User.id_str,
                User.name,
-               DATE_FORMAT(Post.created_at, '%Y-%m-%dT%TZ') as created_at,
+               DATE_FORMAT(Post.created_at, '%Y-%m-%dT%TZ')                   as created_at,
                Post.hit,
                ifnull(Post.excerpt, concat(substr(Post.content, 197), '...')) as excerpt, -- 본문이 200자보다 길다면 197자까지 자르고 '...' 붙이기
-               (select count(*)
-                from Comment c,
-                     User u
-                where c.post_id = Post.id
-                  and u.id = User.id)                                         as num_of_comments
+               (<include refid="getNumOfComments"/>)                           as num_of_comments
         from myBlog.Post
                  left outer join myBlog.User on Post.user_id = User.id
                  left outer join myBlog.Category on Post.category_id = Category.id
@@ -59,51 +65,24 @@
         limit #{offset}, #{limit};
     </select>
 
-    <!--  getPostByTitle 결과 매핑 -->
-    <resultMap id="getPostByTitleResultMap" type="PostDto">
-        <result property="postId" column="post_id"/>
-        <result property="categoryId" column="category_id"/>
-        <result property="categoryName" column="category_name"/>
-        <result property="title" column="title"/>
-        <result property="createdAt" column="post_created_at"/>
-        <result property="hit" column="hit"/>
-        <result property="excerpt" column="excerpt"/>
-        <result property="content" column="content"/>
-        <association property="author" column="author" javaType="AuthorDto">
-            <result property="userId" column="id_str"/>
-            <result property="nickName" column="name"/>
-        </association>
-        <collection property="comments" column="comments" javaType="List" ofType="CommentDto">
-            <result property="commentId" column="comment_id"/>
-            <result property="userId" column="comment_user_id"/>
-            <result property="content" column="comment_content"/>
-            <result property="createdAt" column="comment_created_at"/>
-        </collection>
-    </resultMap>
-
     <!--  getPostByTitle 쿼리 -->
-    <select id="getPostByTitle" parameterType="String" resultMap="getPostByTitleResultMap">
-        select Post.id                                                        as post_id,
+    <select id="getPostByTitle" parameterType="String" resultMap="PostDtoMap">
+        select Post.id,
                Post.category_id,
                Category.name                                                  as category_name,
                Post.title,
                User.id_str,
                User.name,
-               DATE_FORMAT(Post.created_at, '%Y-%m-%dT%TZ')                   as post_created_at,
+               DATE_FORMAT(Post.created_at, '%Y-%m-%dT%TZ')                   as created_at,
                Post.hit,
                ifnull(Post.excerpt, concat(substr(Post.content, 197), '...')) as excerpt,
-               Post.content                                                   as post_content,
-               Comment.id                                                     as comment_id,
-               Comment.user_id                                                as comment_user_id,
-               Comment.content                                                as comment_content,
-               DATE_FORMAT(Comment.created_at, '%Y-%m-%dT%TZ')                as comment_created_at
+               Post.content,
+               (<include refid="getNumOfComments"/>)                           as num_of_comments
         from myBlog.Post
                  left outer join myBlog.User on Post.user_id = User.id
                  left outer join myBlog.Category on Post.category_id = Category.id
-                 left outer join myBlog.Comment on Comment.post_id = Post.id
         where Post.title = #{postTitle}
-          and Post.deleted_at is null
-        order by comment_created_at desc;
+          and Post.deleted_at is null;
     </select>
 
 </mapper>


### PR DESCRIPTION
## 이슈

- #103

## 작업 사항

- 댓글 내용 조회는 getCommentsByPostId로 분리. 글 조회 시에는 댓글 개수만 포함.
- 이를 수정하면서 변수 명도 확인. 기존에 `content`를 조회할 때 쿼리문에는 댓글 본문과 중복을 피하고자 변수명을 `post_content`로 했는데, 이 부분이 제대로 매핑이 안되어 있었음. 댓글 부분 제거했으므로 `content`로 맞춤.

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.
